### PR TITLE
webpack-config file / inject manifest customs

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -3,8 +3,6 @@ const WebpackPwaManifest = require('webpack-pwa-manifest');
 const path = require('path');
 const { InjectManifest } = require('workbox-webpack-plugin');
 
-// TODO: Add and configure workbox plugins for a service worker and manifest file.
-// TODO: Add CSS loaders and babel to webpack. // done
 
 module.exports = () => {
   return {
@@ -26,6 +24,25 @@ module.exports = () => {
       new InjectManifest({
         swSrc: './src-sw.js',
         swDest: 'src-sw.js'
+      }),
+
+      new WebpackPwaManifest({
+        fingerprints: false,
+        filename: 'manifest.json',
+        name: 'text editor',
+        short_name: 'JATE',
+        description: 'Text Editor, keep your notes here!!',
+        background_color: '#225ca3',
+        theme_color: '#225ca3',
+        start_url: '/',
+        publicPath: '/',
+        icons: [
+          {
+            src: path.resolve('src/images/logo.png'),
+            sizes: [96, 128, 192, 256, 384, 512],
+            destination: path.join('assets', 'icons'),
+          }
+        ]
       })
     ],
 


### PR DESCRIPTION
Added to the webpack.config file, the mandatory plugin to register the inject manifest file and set up some custom options