### PR TITLE
deployment ready -- debugging src-sw.js file

### DIFF
--- a/client/src-sw.js
+++ b/client/src-sw.js
@@ -1,5 +1,5 @@
 const { offlineFallback, warmStrategyCache } = require('workbox-recipes');
-const { CacheFirst } = require('workbox-strategies');
+const { CacheFirst, StaleWhileRevalidate } = require('workbox-strategies');
 const { registerRoute } = require('workbox-routing');
 const { CacheableResponsePlugin } = require('workbox-cacheable-response');
 const { ExpirationPlugin } = require('workbox-expiration');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start:dev": "concurrently \" cd client && npm run build \" \" cd server && npm run server\" ",
     "start": "npm run build && cd server && node server.js",
-    "server": " cd server server.js --ignore client",
+    "server": " cd server && node server.js --ignore client",
     "build": "cd client && npm run build",
     "install": " cd server && npm install && cd ../client && npm install",
     "client": "cd client && npm start"

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 3000;
 
 app.use(express.static('../client/dist'));
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
I added the "StaleWhileRevalidate" class to the src-sw.js file in the client folder to fix server issues when testing the application; the class was required with the existing CacheFirst class from the library "workbox strategies",  this change can be found in line 2

